### PR TITLE
Pass clientIP from provider when it's set

### DIFF
--- a/internal/testing/integration_test.go
+++ b/internal/testing/integration_test.go
@@ -18,6 +18,7 @@ var (
 	apiUser     = flag.String("username", "", "Namecheap API username.")
 	apiEndpoint = flag.String("endpoint", "https://api.sandbox.namecheap.com/xml.response", "Namecheap API endpoint.")
 	domain      = flag.String("domain", "", "Domain to test with of the form sld.tld <testing.com>")
+	clientIP    = flag.String("client-ip", "", "Public IP address of client machine")
 )
 
 func TestIntegration(t *testing.T) {
@@ -25,6 +26,7 @@ func TestIntegration(t *testing.T) {
 		APIKey:      *apiKey,
 		User:        *apiUser,
 		APIEndpoint: *apiEndpoint,
+		ClientIP:    *clientIP,
 	}
 
 	newRecords := []libdns.Record{

--- a/provider.go
+++ b/provider.go
@@ -71,6 +71,8 @@ func (p *Provider) getClient() (*namecheap.Client, error) {
 
 	if p.ClientIP == "" {
 		options = append(options, namecheap.AutoDiscoverPublicIP())
+	} else {
+		options = append(options, namecheap.WithClientIP(p.ClientIP))
 	}
 
 	client, err := namecheap.NewClient(p.APIKey, p.User, options...)


### PR DESCRIPTION
Relates to https://github.com/caddy-dns/namecheap/issues/3