### PR TITLE
Downgrade to go 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libdns/namecheap
 
-go 1.24
+go 1.23
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
xcaddy won't build the plugin if the go version is higher than 1.23 for now.