### PR TITLE
Update to libdns v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,13 @@
 
 [![Go Reference](https://pkg.go.dev/badge/test.svg)](https://pkg.go.dev/github.com/libdns/namecheap)
 
-This package implements the [libdns interfaces](https://github.com/libdns/libdns) for namecheap, allowing you to manage DNS records.
+This package implements the [libdns interfaces](https://github.com/libdns/libdns) for namecheap. This is a community project. You should first test that it works for your use case.
 
 ## Usage
 
 See [namecheap api docs](https://www.namecheap.com/support/api/intro/) for details on how to get setup with using the namecheap API.
 
-Once you have an API Key and have whitelisted your client IP, you can begin using this library. There's a simple integration test under `./internal/testing` that can be used for testing with this library and serves as an exmpale for usage. You can pass in your credentials through command line flags:
-
-```shell
-go test ./internal/testing/... -api-key <your_api_key> -username <your_username> -domain example.com.
-```
-
-By default the sandbox URL is used but you can also pass the production endpint with the `-endpoint <url>` flag.
+Once you have an API Key and have whitelisted your client IP, you can begin using this library.
 
 ## Testing
 
@@ -27,3 +21,11 @@ go test -race ./internal/namecheap/...
 ```shell
 go fmt ./...
 ```
+
+There are simple integrations test under `./internal/testing` that can be used for testing with this library and serves as an exmpale for usage. **DO NOT** use this test for production as it will delete your existing records. You can pass in your credentials through command line flags:
+
+```shell
+go test -tags=integration ./internal/testing/... -api-key <your_api_key> -username <your_username> -domain example.com.
+```
+
+By default the sandbox URL is used but you can also pass the production endpint with the `-endpoint <url>` flag.

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.23
 
 require (
 	github.com/google/go-cmp v0.6.0
-	github.com/libdns/libdns v0.2.3
+	github.com/libdns/libdns v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/libdns/libdns v0.2.3 h1:ba30K4ObwMGB/QTmqUxf3H4/GmUrCAIkMWejeGl12v8=
-github.com/libdns/libdns v0.2.3/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.1.0 h1:9ze/tWvt7Df6sbhOJRB8jT33GHEHpEQXdtkE3hPthbU=
+github.com/libdns/libdns v1.1.0/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/internal/namecheap/namecheap_internal_test.go
+++ b/internal/namecheap/namecheap_internal_test.go
@@ -9,23 +9,9 @@ import (
 
 // This mostly tests the xml unmarshaling.
 
-var (
-	namecheapXMLNS = xml.Name{Space: "https://api.namecheap.com/xml.response", Local: "ApiResponse"}
-)
+var namecheapXMLNS = xml.Name{Space: "https://api.namecheap.com/xml.response", Local: "ApiResponse"}
 
 const (
-	setHostsResponse = `<?xml version="1.0" encoding="UTF-8"?>
-<ApiResponse xmlns="https://api.namecheap.com/xml.response" Status="OK">
-  <Errors />
-  <RequestedCommand>namecheap.domains.dns.setHosts</RequestedCommand>
-  <CommandResponse Type="namecheap.domains.dns.setHosts">
-    <DomainDNSSetHostsResult Domain="domain.com" IsSuccess="true" />
-  </CommandResponse>
-  <Server>SERVER-NAME</Server>
-  <GMTTimeDifference>+5</GMTTimeDifference>
-  <ExecutionTime>32.76</ExecutionTime>
-</ApiResponse>`
-
 	getHostsResponse = `<?xml version="1.0" encoding="UTF-8"?>
 <ApiResponse xmlns="https://api.namecheap.com/xml.response" Status="OK">
   <Errors />

--- a/internal/namecheap/namecheap_test.go
+++ b/internal/namecheap/namecheap_test.go
@@ -2,13 +2,11 @@ package namecheap_test
 
 import (
 	"context"
-	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -44,20 +42,6 @@ const (
   <ExecutionTime>32.76</ExecutionTime>
 </ApiResponse>`
 
-	getHostsResponseTmpl = `<?xml version="1.0" encoding="UTF-8"?>
-<ApiResponse xmlns="http://api.namecheap.com/xml.response" Status="OK">
-  <Errors />
-  <RequestedCommand>namecheap.domains.dns.getHosts</RequestedCommand>
-  <CommandResponse Type="namecheap.domains.dns.getHosts">
-    <DomainDNSGetHostsResult Domain="domain.com" IsUsingOurDNS="true">
-      %s
-    </DomainDNSGetHostsResult>
-  </CommandResponse>
-  <Server>SERVER-NAME</Server>
-  <GMTTimeDifference>+5</GMTTimeDifference>
-  <ExecutionTime>32.76</ExecutionTime>
-</ApiResponse>`
-
 	emptyHostsResponse = `<?xml version="1.0" encoding="UTF-8"?>
 <ApiResponse xmlns="http://api.namecheap.com/xml.response" Status="OK">
   <Errors />
@@ -81,12 +65,35 @@ const (
   <GMTTimeDifference>--1:00</GMTTimeDifference>
   <ExecutionTime>0</ExecutionTime>
 </ApiResponse>`
+
+	getTLDListResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ApiResponse xmlns="http://api.namecheap.com/xml.response" Status="OK">
+  <Errors />
+  <RequestedCommand>namecheap.domains.getTldList</RequestedCommand>
+  <CommandResponse Type="namecheap.domains.getTldList">
+    <Tlds>
+      <Tld Name="biz" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="true" IsApiRenewable="true" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="false" SequenceNumber="5" Type="GTLD" IsSupportsIDN="false" Category="P">US Business</Tld>
+      <Tld Name="bz" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="false" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="true" SequenceNumber="11" Type="CCTLD" IsSupportsIDN="false" Category="A">BZ Country Domain</Tld>
+      <Tld Name="ca" NonRealTime="true" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="false" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="true" SequenceNumber="7" Type="CCTLD" IsSupportsIDN="false" Category="A">Canada Country TLD</Tld>
+      <Tld Name="cc" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="false" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="true" SequenceNumber="9" Type="CCTLD" IsSupportsIDN="false" Category="A">CC TLD</Tld>
+      <Tld Name="co.uk" NonRealTime="false" MinRegisterYears="2" MaxRegisterYears="10" MinRenewYears="2" MaxRenewYears="10" MinTransferYears="2" MaxTransferYears="10" IsApiRegisterable="true" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="false" SequenceNumber="18" Type="CCTLD" IsSupportsIDN="false" Category="A">UK based domain</Tld>
+      <Tld Name="com" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="true" IsApiRenewable="true" IsApiTransferable="true" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="false" SequenceNumber="1" Type="GTLD" IsSupportsIDN="false" Category="G">COM Generic Top-level Domain</Tld>
+    </Tlds>
+  </CommandResponse>
+  <Server>IMWS-A06</Server>
+  <GMTTimeDifference>+5:30</GMTTimeDifference>
+  <ExecutionTime>0.047</ExecutionTime>
+</ApiResponse>`
 )
 
-func ensureQueryParams(t *testing.T, r *http.Request, expectedQueryParams url.Values) {
+func ensureBody(t *testing.T, r *http.Request, expectedBody string) {
 	t.Helper()
-	if diff := cmp.Diff(expectedQueryParams, r.URL.Query()); diff != "" {
-		t.Fatalf("Expected query params does not match received: %s", diff)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(expectedBody, string(body)); diff != "" {
+		t.Fatalf("Expected body does not match received: %s", diff)
 	}
 }
 
@@ -109,7 +116,7 @@ func TestGetHosts(t *testing.T) {
 		"SLD":      "any",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ensureQueryParams(t, r, toURLValues(expectedValues))
+		ensureBody(t, r, toURLValues(expectedValues).Encode())
 		_, err := w.Write([]byte(getHostsResponse))
 		if err != nil {
 			t.Fatal(err)
@@ -122,12 +129,14 @@ func TestGetHosts(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	hosts, err := c.GetHosts(context.TODO(), "any.domain")
+	hosts, err := c.GetHosts(context.TODO(), namecheap.Domain{
+		TLD: "domain",
+		SLD: "any",
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	// Test that hosts unmarshal correctly.
 	expectedHosts := map[string]namecheap.HostRecord{
 		"12": {
 			Name:       "@",
@@ -163,7 +172,6 @@ func TestGetHosts(t *testing.T) {
 }
 
 func TestGetHostsContextCanceled(t *testing.T) {
-	// Testing that the request context gets canceled
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		select {
 		case <-r.Context().Done():
@@ -181,7 +189,10 @@ func TestGetHostsContextCanceled(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if _, err := c.GetHosts(ctx, "any.domain"); err == nil {
+	if _, err := c.GetHosts(ctx, namecheap.Domain{
+		TLD: "domain",
+		SLD: "any",
+	}); err == nil {
 		t.Fatal("Expected error cancelling context but got none")
 	}
 }
@@ -197,7 +208,7 @@ func TestGetHostsWithExtraDotInDomain(t *testing.T) {
 		"SLD":      "any",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ensureQueryParams(t, r, toURLValues(expectedValues))
+		ensureBody(t, r, toURLValues(expectedValues).Encode())
 		_, err := w.Write([]byte(getHostsResponse))
 		if err != nil {
 			t.Fatal(err)
@@ -210,7 +221,10 @@ func TestGetHostsWithExtraDotInDomain(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	if _, err := c.GetHosts(context.TODO(), "any.domain."); err != nil {
+	if _, err := c.GetHosts(context.TODO(), namecheap.Domain{
+		TLD: "domain",
+		SLD: "any",
+	}); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 }
@@ -226,7 +240,7 @@ func TestGetHostsWithExtraDotsInTLD(t *testing.T) {
 		"SLD":      "any",
 	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ensureQueryParams(t, r, toURLValues(expectedValues))
+		ensureBody(t, r, toURLValues(expectedValues).Encode())
 		_, err := w.Write([]byte(getHostsResponse))
 		if err != nil {
 			t.Fatal(err)
@@ -239,7 +253,10 @@ func TestGetHostsWithExtraDotsInTLD(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	if _, err := c.GetHosts(context.TODO(), "any.co.uk"); err != nil {
+	if _, err := c.GetHosts(context.TODO(), namecheap.Domain{
+		TLD: "co.uk",
+		SLD: "any",
+	}); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 }
@@ -262,7 +279,7 @@ func TestSetHosts(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expected))
+			ensureBody(t, r, toURLValues(expected).Encode())
 			w.Write([]byte(setHostsResponse))
 		case http.MethodGet:
 			w.Write([]byte(emptyHostsResponse))
@@ -286,218 +303,10 @@ func TestSetHosts(t *testing.T) {
 		},
 	}
 
-	_, err = c.SetHosts(context.TODO(), "domain.com", hosts)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-}
-
-func TestSetHostsUpdatesExisting(t *testing.T) {
-	expected := map[string]string{
-		"ApiUser":     "testUser",
-		"ApiKey":      "testAPIKey",
-		"UserName":    "testUser",
-		"ClientIp":    "localhost",
-		"Command":     "namecheap.domains.dns.setHosts",
-		"TLD":         "com",
-		"SLD":         "domain",
-		"HostName1":   "@",
-		"RecordType1": string(namecheap.A),
-		"Address1":    "0.0.0.0",
-		"TTL1":        "1800",
-		"HostName2":   "www",
-		"RecordType2": string(namecheap.A),
-		"Address2":    "122.23.3.7",
-		"MXPref2":     "10",
-		"TTL2":        "1800",
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expected))
-			w.Write([]byte(setHostsResponse))
-		case http.MethodGet:
-			w.Write([]byte(getHostsResponse))
-		}
-	}))
-	t.Cleanup(ts.Close)
-	c, err := namecheap.NewClient("testAPIKey", "testUser", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("localhost"))
-	if err != nil {
-		t.Fatalf("Error creating NewClient. Err: %s", err)
-	}
-
-	hosts := []namecheap.HostRecord{
-		{
-			Name:       "@",
-			RecordType: namecheap.A,
-			TTL:        uint16(1800),
-			HostID:     "12",
-			Address:    "0.0.0.0",
-		},
-	}
-
-	_, err = c.SetHosts(context.TODO(), "domain.com", hosts)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-}
-
-func TestSetHostsAddsAndKeepsExisting(t *testing.T) {
-	expected := map[string]string{
-		"ApiUser":     "testUser",
-		"ApiKey":      "testAPIKey",
-		"UserName":    "testUser",
-		"ClientIp":    "localhost",
-		"Command":     "namecheap.domains.dns.setHosts",
-		"TLD":         "com",
-		"SLD":         "domain",
-		"Address1":    "1.2.3.4",
-		"HostName1":   "@",
-		"RecordType1": string(namecheap.A),
-		"MXPref1":     "10",
-		"TTL1":        "1800",
-		"Address2":    "122.23.3.7",
-		"HostName2":   "www",
-		"RecordType2": string(namecheap.A),
-		"MXPref2":     "10",
-		"TTL2":        "1800",
-		"HostName3":   "www",
-		"RecordType3": string(namecheap.A),
-		"TTL3":        "900",
-		"Address3":    "127.0.0.1",
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expected))
-			w.Write([]byte(setHostsResponse))
-		case http.MethodGet:
-			w.Write([]byte(getHostsResponse))
-		}
-	}))
-	t.Cleanup(ts.Close)
-	c, err := namecheap.NewClient("testAPIKey", "testUser", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("localhost"))
-	if err != nil {
-		t.Fatalf("Error creating NewClient. Err: %s", err)
-	}
-
-	hosts := []namecheap.HostRecord{
-		{
-			Name:       "www",
-			RecordType: namecheap.A,
-			TTL:        uint16(900),
-			Address:    "127.0.0.1",
-		},
-	}
-
-	_, err = c.SetHosts(context.TODO(), "domain.com", hosts)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-}
-
-func TestAddHostsNoExisting(t *testing.T) {
-	expectedValues := map[string]string{
-		"ApiUser":     "testUser",
-		"ApiKey":      "testAPIKey",
-		"UserName":    "testUser",
-		"ClientIp":    "localhost",
-		"Command":     "namecheap.domains.dns.setHosts",
-		"TLD":         "com",
-		"SLD":         "domain",
-		"HostName1":   "first_host",
-		"RecordType1": string(namecheap.A),
-		"TTL1":        "180",
-		"HostName2":   "second_host",
-		"RecordType2": string(namecheap.A),
-	}
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expectedValues))
-			w.Write([]byte(setHostsResponse))
-		case http.MethodGet:
-			w.Write([]byte(emptyHostsResponse))
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	c, err := namecheap.NewClient("testAPIKey", "testUser", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("localhost"))
-	if err != nil {
-		t.Fatalf("Error creating NewClient. Err: %s", err)
-	}
-
-	newHosts := []namecheap.HostRecord{
-		{
-			Name:       "first_host",
-			RecordType: namecheap.A,
-			TTL:        uint16(180),
-		},
-		{
-			Name:       "second_host",
-			RecordType: namecheap.A,
-		},
-	}
-	_, err = c.AddHosts(context.TODO(), "domain.com", newHosts)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-}
-
-func TestAddHostsWithExisting(t *testing.T) {
-	expectedValues := map[string]string{
-		"ApiUser":     "testUser",
-		"ApiKey":      "testAPIKey",
-		"UserName":    "testUser",
-		"ClientIp":    "localhost",
-		"Command":     "namecheap.domains.dns.setHosts",
-		"TLD":         "com",
-		"SLD":         "domain",
-		"Address1":    "1.2.3.4",
-		"MXPref1":     "10",
-		"HostName1":   "@",
-		"RecordType1": string(namecheap.A),
-		"TTL1":        "1800",
-		"Address2":    "122.23.3.7",
-		"MXPref2":     "10",
-		"HostName2":   "www",
-		"RecordType2": string(namecheap.A),
-		"TTL2":        "1800",
-		"HostName3":   "third_host",
-		"RecordType3": string(namecheap.A),
-		"TTL3":        "180",
-		"HostName4":   "fourth_host",
-		"RecordType4": string(namecheap.A),
-	}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expectedValues))
-			w.Write([]byte(setHostsResponse))
-		case http.MethodGet:
-			w.Write([]byte(getHostsResponse))
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	c, err := namecheap.NewClient("testAPIKey", "testUser", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("localhost"))
-	if err != nil {
-		t.Fatalf("Error creating NewClient. Err: %s", err)
-	}
-
-	newHosts := []namecheap.HostRecord{
-		{
-			Name:       "third_host",
-			RecordType: namecheap.A,
-			TTL:        uint16(180),
-		},
-		{
-			Name:       "fourth_host",
-			RecordType: namecheap.A,
-		},
-	}
-	_, err = c.AddHosts(context.TODO(), "domain.com", newHosts)
+	_, err = c.SetHosts(context.TODO(), namecheap.Domain{
+		TLD: "com",
+		SLD: "domain",
+	}, hosts)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -514,7 +323,10 @@ func TestGetHostsError(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	_, err = c.GetHosts(context.TODO(), "any.domain")
+	_, err = c.GetHosts(context.TODO(), namecheap.Domain{
+		TLD: "domain",
+		SLD: "any",
+	})
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
@@ -526,12 +338,15 @@ func TestBadURL(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	_, err = c.GetHosts(context.TODO(), "com")
+	_, err = c.GetHosts(context.TODO(), namecheap.Domain{
+		TLD: "com",
+		SLD: "any",
+	})
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
 
-	_, err = c.GetHosts(context.TODO(), "")
+	_, err = c.GetHosts(context.TODO(), namecheap.Domain{})
 	if err == nil {
 		t.Fatal("Expected error but got nil")
 	}
@@ -553,32 +368,25 @@ func TestAutoDiscoverIP(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	c.GetHosts(context.TODO(), "any.domain")
+	c.GetHosts(context.TODO(), namecheap.Domain{
+		TLD: "domain",
+		SLD: "any",
+	})
 }
 
-func TestDeleteHostsWithExisting(t *testing.T) {
+func TestGetTLDs(t *testing.T) {
 	expectedValues := map[string]string{
-		"ApiUser":     "testUser",
-		"ApiKey":      "testAPIKey",
-		"UserName":    "testUser",
-		"ClientIp":    "localhost",
-		"Command":     "namecheap.domains.dns.setHosts",
-		"TLD":         "com",
-		"SLD":         "domain",
-		"Address1":    "1.2.3.4",
-		"MXPref1":     "10",
-		"HostName1":   "@",
-		"RecordType1": string(namecheap.A),
-		"TTL1":        "1800",
+		"ApiUser":  "testUser",
+		"ApiKey":   "testAPIKey",
+		"UserName": "testUser",
+		"ClientIp": "localhost",
+		"Command":  "namecheap.domains.getTldList",
 	}
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expectedValues))
-			w.Write([]byte(setHostsResponse))
-		case http.MethodGet:
-			w.Write([]byte(getHostsResponse))
+		ensureBody(t, r, toURLValues(expectedValues).Encode())
+		_, err := w.Write([]byte(getTLDListResponse))
+		if err != nil {
+			t.Fatal(err)
 		}
 	}))
 	t.Cleanup(ts.Close)
@@ -588,352 +396,37 @@ func TestDeleteHostsWithExisting(t *testing.T) {
 		t.Fatalf("Error creating NewClient. Err: %s", err)
 	}
 
-	hostsToDelete := []namecheap.HostRecord{
-		{
-			HostID: "14",
-		},
-	}
-	hosts, err := c.DeleteHosts(context.TODO(), "domain.com", hostsToDelete)
+	tlds, err := c.GetTLDs(context.TODO())
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	if len(hosts) != 1 {
-		t.Fatalf("Expected 1 host. Got: %v", len(hosts))
-	}
-}
-
-func TestDeleteHostsNoExisting(t *testing.T) {
-	expectedValues := map[string]string{
-		"ApiUser":     "testUser",
-		"ApiKey":      "testAPIKey",
-		"UserName":    "testUser",
-		"ClientIp":    "localhost",
-		"Command":     "namecheap.domains.dns.setHosts",
-		"TLD":         "com",
-		"SLD":         "domain",
-		"Address1":    "1.2.3.4",
-		"MXPref1":     "10",
-		"HostName1":   "@",
-		"RecordType1": string(namecheap.A),
-		"TTL1":        "1800",
-		"Address2":    "122.23.3.7",
-		"MXPref2":     "10",
-		"HostName2":   "www",
-		"RecordType2": string(namecheap.A),
-		"TTL2":        "1800",
+	expectedTLDs := []namecheap.TLD{
+		{Name: "biz"},
+		{Name: "bz"},
+		{Name: "ca"},
+		{Name: "cc"},
+		{Name: "co.uk"},
+		{Name: "com"},
 	}
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.Method {
-		case http.MethodPost:
-			ensureQueryParams(t, r, toURLValues(expectedValues))
-			w.Write([]byte(setHostsResponse))
-		case http.MethodGet:
-			w.Write([]byte(getHostsResponse))
+	if diff := cmp.Diff(expectedTLDs, tlds); diff != "" {
+		t.Fatalf("Expected TLDs does not match: %s", diff)
+	}
+
+	if len(tlds) != 6 {
+		t.Errorf("Expected 6 TLDs, got %d", len(tlds))
+	}
+
+	tldNames := make(map[string]bool)
+	for _, tld := range tlds {
+		tldNames[tld.Name] = true
+	}
+
+	expectedNames := []string{"biz", "bz", "ca", "cc", "co.uk", "com"}
+	for _, name := range expectedNames {
+		if !tldNames[name] {
+			t.Errorf("Expected TLD %s not found in results", name)
 		}
-	}))
-	t.Cleanup(ts.Close)
-
-	c, err := namecheap.NewClient("testAPIKey", "testUser", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("localhost"))
-	if err != nil {
-		t.Fatalf("Error creating NewClient. Err: %s", err)
-	}
-
-	hostsToDelete := []namecheap.HostRecord{
-		{
-			HostID: "nonexistanthost",
-		},
-	}
-	hosts, err := c.DeleteHosts(context.TODO(), "domain.com", hostsToDelete)
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
-	}
-
-	if len(hosts) != 2 {
-		t.Fatalf("Expected 2 host. Got: %v", len(hosts))
-	}
-}
-
-func mustParseUint(t *testing.T, s string) uint {
-	t.Helper()
-	if s == "" {
-		return 0
-	}
-	i, err := strconv.ParseUint(s, 10, 16)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return uint(i)
-}
-
-func setupTestServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	var (
-		hostsMu sync.Mutex
-		hosts   = make([]namecheap.HostRecord, 0)
-	)
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hostsMu.Lock()
-		defer hostsMu.Unlock()
-
-		switch r.Method {
-		case http.MethodPost:
-			if err := r.ParseForm(); err != nil {
-				t.Errorf("Failed to parse form: %v", err)
-				return
-			}
-
-			hosts = make([]namecheap.HostRecord, 0)
-			for i := 1; ; i++ {
-				name := r.Form.Get(fmt.Sprintf("HostName%d", i))
-				if name == "" {
-					break
-				}
-				record := namecheap.HostRecord{
-					// The host ids can change from request to request.
-					HostID:     strconv.Itoa(i),
-					Name:       name,
-					RecordType: namecheap.RecordType(r.Form.Get(fmt.Sprintf("RecordType%d", i))),
-					Address:    r.Form.Get(fmt.Sprintf("Address%d", i)),
-					MXPref:     r.Form.Get(fmt.Sprintf("MXPref%d", i)),
-					TTL:        uint16(mustParseUint(t, r.Form.Get(fmt.Sprintf("TTL%d", i)))),
-				}
-				hosts = append(hosts, record)
-			}
-
-			w.Write([]byte(setHostsResponse))
-
-		case http.MethodGet:
-			var hostsXML strings.Builder
-			for _, host := range hosts {
-				hostsXML.WriteString(fmt.Sprintf(
-					`<Host HostId="%s" Name="%s" Type="%s" Address="%s" MXPref="%s" TTL="%d" />`,
-					host.HostID,
-					host.Name,
-					host.RecordType,
-					host.Address,
-					host.MXPref,
-					host.TTL,
-				))
-			}
-
-			response := fmt.Sprintf(getHostsResponseTmpl, hostsXML.String())
-			w.Write([]byte(response))
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	return ts
-}
-
-func TestConcurrentDeleteHosts(t *testing.T) {
-	ts := setupTestServer(t)
-
-	client, err := namecheap.NewClient("test-key", "test-user", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("127.0.0.1"))
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	domain := "example.com"
-
-	record1 := namecheap.HostRecord{
-		Name:       "test1",
-		RecordType: namecheap.A,
-		Address:    "1.1.1.1",
-		TTL:        1800,
-	}
-	record2 := namecheap.HostRecord{
-		Name:       "test2",
-		RecordType: namecheap.A,
-		Address:    "2.2.2.2",
-		TTL:        1800,
-	}
-	record3 := namecheap.HostRecord{
-		Name:       "test3",
-		RecordType: namecheap.A,
-		Address:    "3.3.3.3",
-		TTL:        1800,
-	}
-
-	_, err = client.AddHosts(context.Background(), domain, []namecheap.HostRecord{record1, record2, record3})
-	if err != nil {
-		t.Fatalf("Failed to add initial records: %v", err)
-	}
-
-	// Get the hosts because the host ids are not set in the AddHosts response.
-	hosts, err := client.GetHosts(context.Background(), domain)
-	if err != nil {
-		t.Fatalf("Failed to get hosts: %v", err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		_, err := client.DeleteHosts(context.Background(), domain, []namecheap.HostRecord{hosts[0]})
-		if err != nil {
-			t.Errorf("First DeleteHosts failed: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		_, err := client.DeleteHosts(context.Background(), domain, []namecheap.HostRecord{hosts[1]})
-		if err != nil {
-			t.Errorf("Second DeleteHosts failed: %v", err)
-		}
-	}()
-
-	wg.Wait()
-
-	remainingRecords, err := client.GetHosts(context.Background(), domain)
-	if err != nil {
-		t.Fatalf("Failed to get remaining records: %v", err)
-	}
-
-	if len(remainingRecords) != 1 {
-		t.Errorf("Expected 1 remaining record, got %d", len(remainingRecords))
-	}
-	if remainingRecords[0].Name != hosts[2].Name || remainingRecords[0].Address != hosts[2].Address {
-		t.Errorf("Expected remaining record to match record3 (Name: %s, Address: %s), got (Name: %s, Address: %s)",
-			hosts[2].Name, hosts[2].Address, remainingRecords[0].Name, remainingRecords[0].Address)
-	}
-}
-
-func TestConcurrentAddHosts(t *testing.T) {
-	ts := setupTestServer(t)
-
-	client, err := namecheap.NewClient("test-key", "test-user", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("127.0.0.1"))
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	domain := "example.com"
-
-	record1 := namecheap.HostRecord{
-		Name:       "test1",
-		RecordType: namecheap.A,
-		Address:    "1.1.1.1",
-		TTL:        1800,
-	}
-	record2 := namecheap.HostRecord{
-		Name:       "test2",
-		RecordType: namecheap.A,
-		Address:    "2.2.2.2",
-		TTL:        1800,
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		_, err := client.AddHosts(context.Background(), domain, []namecheap.HostRecord{record1})
-		if err != nil {
-			t.Errorf("First AddHosts failed: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		_, err := client.AddHosts(context.Background(), domain, []namecheap.HostRecord{record2})
-		if err != nil {
-			t.Errorf("Second AddHosts failed: %v", err)
-		}
-	}()
-
-	wg.Wait()
-
-	remainingRecords, err := client.GetHosts(context.Background(), domain)
-	if err != nil {
-		t.Fatalf("Failed to get remaining records: %v", err)
-	}
-
-	if len(remainingRecords) != 2 {
-		t.Errorf("Expected 2 records, got %d", len(remainingRecords))
-	}
-
-	recordMap := make(map[string]namecheap.HostRecord)
-	for _, r := range remainingRecords {
-		recordMap[r.Name+r.Address] = r
-	}
-	if _, exists := recordMap[record1.Name+record1.Address]; !exists {
-		t.Error("record1 was not added")
-	}
-	if _, exists := recordMap[record2.Name+record2.Address]; !exists {
-		t.Error("record2 was not added")
-	}
-}
-
-func TestConcurrentSetHosts(t *testing.T) {
-	ts := setupTestServer(t)
-
-	client, err := namecheap.NewClient("test-key", "test-user", namecheap.WithEndpoint(ts.URL), namecheap.WithClientIP("127.0.0.1"))
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	domain := "example.com"
-
-	record1 := namecheap.HostRecord{
-		Name:       "test1",
-		RecordType: namecheap.A,
-		Address:    "1.1.1.1",
-		TTL:        1800,
-	}
-
-	_, err = client.SetHosts(context.Background(), domain, []namecheap.HostRecord{record1})
-	if err != nil {
-		t.Fatalf("Failed to add initial record: %v", err)
-	}
-
-	// Get the hosts because the host ids are not set in the AddHosts response.
-	hosts, err := client.GetHosts(context.Background(), domain)
-	if err != nil {
-		t.Fatalf("Failed to get hosts: %v", err)
-	}
-
-	modifiedRecord1 := hosts[0]
-	modifiedRecord1.Address = "1.1.1.2"
-
-	modifiedRecord1Again := hosts[0]
-	modifiedRecord1Again.Address = "1.1.1.3"
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		_, err := client.SetHosts(context.Background(), domain, []namecheap.HostRecord{modifiedRecord1})
-		if err != nil {
-			t.Errorf("First SetHosts failed: %v", err)
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		_, err := client.SetHosts(context.Background(), domain, []namecheap.HostRecord{modifiedRecord1Again})
-		if err != nil {
-			t.Errorf("Second SetHosts failed: %v", err)
-		}
-	}()
-
-	wg.Wait()
-
-	remainingRecords, err := client.GetHosts(context.Background(), domain)
-	if err != nil {
-		t.Fatalf("Failed to get remaining records: %v", err)
-	}
-
-	if len(remainingRecords) != 1 {
-		t.Errorf("Expected 1 record, got %d", len(remainingRecords))
-	}
-
-	if remainingRecords[0].Address != modifiedRecord1.Address && remainingRecords[0].Address != modifiedRecord1Again.Address {
-		t.Errorf("Record was not properly updated. Got address: %s, expected either %s or %s",
-			remainingRecords[0].Address, modifiedRecord1.Address, modifiedRecord1Again.Address)
 	}
 }

--- a/internal/namecheap/testing.go
+++ b/internal/namecheap/testing.go
@@ -1,0 +1,132 @@
+package namecheap
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const (
+	setHostsResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ApiResponse xmlns="https://api.namecheap.com/xml.response" Status="OK">
+  <Errors />
+  <RequestedCommand>namecheap.domains.dns.setHosts</RequestedCommand>
+  <CommandResponse Type="namecheap.domains.dns.setHosts">
+    <DomainDNSSetHostsResult Domain="domain.com" IsSuccess="true" />
+  </CommandResponse>
+  <Server>SERVER-NAME</Server>
+  <GMTTimeDifference>+5</GMTTimeDifference>
+  <ExecutionTime>32.76</ExecutionTime>
+</ApiResponse>`
+
+	getHostsResponseTmpl = `<?xml version="1.0" encoding="UTF-8"?>
+<ApiResponse xmlns="http://api.namecheap.com/xml.response" Status="OK">
+  <Errors />
+  <RequestedCommand>namecheap.domains.dns.getHosts</RequestedCommand>
+  <CommandResponse Type="namecheap.domains.dns.getHosts">
+    <DomainDNSGetHostsResult Domain="domain.com" IsUsingOurDNS="true">
+      %s
+    </DomainDNSGetHostsResult>
+  </CommandResponse>
+  <Server>SERVER-NAME</Server>
+  <GMTTimeDifference>+5</GMTTimeDifference>
+  <ExecutionTime>32.76</ExecutionTime>
+</ApiResponse>`
+
+	getTLDListResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ApiResponse xmlns="http://api.namecheap.com/xml.response" Status="OK">
+  <Errors />
+  <RequestedCommand>namecheap.domains.getTldList</RequestedCommand>
+  <CommandResponse Type="namecheap.domains.getTldList">
+    <Tlds>
+      <Tld Name="biz" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="true" IsApiRenewable="true" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="false" SequenceNumber="5" Type="GTLD" IsSupportsIDN="false" Category="P">US Business</Tld>
+      <Tld Name="bz" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="false" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="true" SequenceNumber="11" Type="CCTLD" IsSupportsIDN="false" Category="A">BZ Country Domain</Tld>
+      <Tld Name="ca" NonRealTime="true" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="false" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="true" SequenceNumber="7" Type="CCTLD" IsSupportsIDN="false" Category="A">Canada Country TLD</Tld>
+      <Tld Name="cc" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="false" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="true" SequenceNumber="9" Type="CCTLD" IsSupportsIDN="false" Category="A">CC TLD</Tld>
+      <Tld Name="co.uk" NonRealTime="false" MinRegisterYears="2" MaxRegisterYears="10" MinRenewYears="2" MaxRenewYears="10" MinTransferYears="2" MaxTransferYears="10" IsApiRegisterable="true" IsApiRenewable="false" IsApiTransferable="false" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="false" SequenceNumber="18" Type="CCTLD" IsSupportsIDN="false" Category="A">UK based domain</Tld>
+      <Tld Name="com" NonRealTime="false" MinRegisterYears="1" MaxRegisterYears="10" MinRenewYears="1" MaxRenewYears="10" MinTransferYears="1" MaxTransferYears="10" IsApiRegisterable="true" IsApiRenewable="true" IsApiTransferable="true" IsEppRequired="false" IsDisableModContact="false" IsDisableWGAllot="false" IsIncludeInExtendedSearchOnly="false" SequenceNumber="1" Type="GTLD" IsSupportsIDN="false" Category="G">COM Generic Top-level Domain</Tld>
+    </Tlds>
+  </CommandResponse>
+  <Server>IMWS-A06</Server>
+  <GMTTimeDifference>+5:30</GMTTimeDifference>
+  <ExecutionTime>0.047</ExecutionTime>
+</ApiResponse>`
+)
+
+func mustParseUint(t *testing.T, s string) uint {
+	t.Helper()
+	if s == "" {
+		return 0
+	}
+	i, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return uint(i)
+}
+
+func SetupTestServer(t *testing.T, hosts ...HostRecord) *httptest.Server {
+	t.Helper()
+	hostsMu := sync.Mutex{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hostsMu.Lock()
+		defer hostsMu.Unlock()
+
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("Failed to parse form: %v", err)
+			return
+		}
+
+		switch r.Form.Get("Command") {
+		case "namecheap.domains.dns.setHosts":
+			hosts = make([]HostRecord, 0)
+			for i := 1; ; i++ {
+				name := r.Form.Get(fmt.Sprintf("HostName%d", i))
+				if name == "" {
+					break
+				}
+				record := HostRecord{
+					// The host ids can change from request to request.
+					HostID:     strconv.Itoa(i),
+					Name:       name,
+					RecordType: RecordType(r.Form.Get(fmt.Sprintf("RecordType%d", i))),
+					Address:    r.Form.Get(fmt.Sprintf("Address%d", i)),
+					MXPref:     r.Form.Get(fmt.Sprintf("MXPref%d", i)),
+					TTL:        uint16(mustParseUint(t, r.Form.Get(fmt.Sprintf("TTL%d", i)))),
+				}
+				hosts = append(hosts, record)
+			}
+
+			w.Write([]byte(setHostsResponse))
+
+		case "namecheap.domains.getTldList":
+			w.Write([]byte(getTLDListResponse))
+			return
+
+		case "namecheap.domains.dns.getHosts":
+			var hostsXML strings.Builder
+			for _, host := range hosts {
+				hostsXML.WriteString(fmt.Sprintf(
+					`<Host HostId="%s" Name="%s" Type="%s" Address="%s" MXPref="%s" TTL="%d" />`,
+					host.HostID,
+					host.Name,
+					host.RecordType,
+					host.Address,
+					host.MXPref,
+					host.TTL,
+				))
+			}
+
+			response := fmt.Sprintf(getHostsResponseTmpl, hostsXML.String())
+			w.Write([]byte(response))
+		}
+	}))
+	t.Cleanup(ts.Close)
+
+	return ts
+}

--- a/internal/testing/integration_test.go
+++ b/internal/testing/integration_test.go
@@ -1,8 +1,15 @@
+//go:build integration
+
 package testing
 
 import (
 	"context"
 	"flag"
+	"net/netip"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +28,39 @@ var (
 	clientIP    = flag.String("client-ip", "", "Public IP address of client machine")
 )
 
+var thirtyMinutes = time.Minute * 30
+
+// cleanupRecords deletes all records for the given domain.
+func cleanupRecords(t *testing.T, p *namecheap.Provider, domain string) {
+	t.Helper()
+	t.Logf("Cleaning up records for %s", domain)
+	records, err := p.GetRecords(context.TODO(), domain)
+	if err != nil {
+		t.Fatalf("Failed to get records for cleanup: %v", err)
+	}
+	if len(records) > 0 {
+		t.Logf("Found %d records to clean up: %#v", len(records), records)
+		for _, record := range records {
+			t.Logf("Deleting record: %#v", record)
+		}
+		_, err = p.DeleteRecords(context.TODO(), domain, records)
+		if err != nil {
+			t.Fatalf("Failed to delete records during cleanup: %v", err)
+		}
+		// Verify cleanup
+		remainingRecords, err := p.GetRecords(context.TODO(), domain)
+		if err != nil {
+			t.Fatalf("Failed to verify cleanup: %v", err)
+		}
+		if len(remainingRecords) > 0 {
+			t.Fatalf("Cleanup failed: %d records still remain: %#v", len(remainingRecords), remainingRecords)
+		}
+		t.Logf("Successfully cleaned up all records")
+	} else {
+		t.Logf("No records found to clean up")
+	}
+}
+
 func TestIntegration(t *testing.T) {
 	p := &namecheap.Provider{
 		APIKey:      *apiKey,
@@ -29,18 +69,21 @@ func TestIntegration(t *testing.T) {
 		ClientIP:    *clientIP,
 	}
 
+	cleanupRecords(t, p, *domain)
+	t.Cleanup(func() {
+		cleanupRecords(t, p, *domain)
+	})
+
 	newRecords := []libdns.Record{
-		{
-			Type:  "A",
-			Name:  "@",
-			Value: "127.0.0.1",
-			TTL:   time.Second * 1799,
+		&libdns.Address{
+			Name: "@",
+			IP:   netip.MustParseAddr("127.0.0.1"),
+			TTL:  thirtyMinutes,
 		},
-		{
-			Type:  "A",
-			Name:  "www",
-			Value: "127.0.0.1",
-			TTL:   time.Second * 1799,
+		&libdns.Address{
+			Name: "www",
+			IP:   netip.MustParseAddr("127.0.0.1"),
+			TTL:  thirtyMinutes,
 		},
 	}
 
@@ -58,9 +101,19 @@ func TestIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// IDs are not returned by append. Maybe they should be?
-	ignoreIDField := cmpopts.IgnoreFields(libdns.Record{}, "ID")
-	if diff := cmp.Diff(addedRecords, records, ignoreIDField); diff != "" {
+	if len(records) != len(newRecords) {
+		t.Fatalf("Expected %d records, got %d", len(newRecords), len(records))
+	}
+
+	// Sort records by name to ensure consistent comparison
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].(*libdns.Address).Name < records[j].(*libdns.Address).Name
+	})
+	sort.Slice(addedRecords, func(i, j int) bool {
+		return addedRecords[i].(*libdns.Address).Name < addedRecords[j].(*libdns.Address).Name
+	})
+
+	if diff := cmp.Diff(addedRecords, records, cmpopts.EquateComparable(netip.Addr{})); diff != "" {
 		t.Fatalf("Added records not equal to fetched records. Diff: %s", diff)
 	}
 
@@ -91,20 +144,24 @@ func TestSetRecordsKeepsExisting(t *testing.T) {
 		APIKey:      *apiKey,
 		User:        *apiUser,
 		APIEndpoint: *apiEndpoint,
+		ClientIP:    *clientIP,
 	}
 
+	cleanupRecords(t, p, *domain)
+	t.Cleanup(func() {
+		cleanupRecords(t, p, *domain)
+	})
+
 	newRecords := []libdns.Record{
-		{
-			Type:  "A",
-			Name:  "@",
-			Value: "127.0.0.1",
-			TTL:   time.Second * 1799,
+		&libdns.Address{
+			Name: "@",
+			IP:   netip.MustParseAddr("127.0.0.1"),
+			TTL:  thirtyMinutes,
 		},
-		{
-			Type:  "A",
-			Name:  "www",
-			Value: "127.0.0.1",
-			TTL:   time.Second * 1799,
+		&libdns.Address{
+			Name: "www",
+			IP:   netip.MustParseAddr("127.0.0.1"),
+			TTL:  thirtyMinutes,
 		},
 	}
 
@@ -126,7 +183,9 @@ func TestSetRecordsKeepsExisting(t *testing.T) {
 		t.Fatalf("Expected 2 records. Got: %d", len(records))
 	}
 
-	records[0].Value = "0.0.0.0"
+	if rr, ok := records[0].(*libdns.Address); ok {
+		rr.IP = netip.MustParseAddr("0.0.0.0")
+	}
 
 	t.Log("Updating record")
 	updatedRecords, err := p.SetRecords(context.TODO(), *domain, records)
@@ -149,14 +208,135 @@ func TestSetRecordsKeepsExisting(t *testing.T) {
 		t.Fatalf("Expected 2 records. Got: %d", len(updatedRecords))
 	}
 
-	var updatedRecord *libdns.Record
+	var updatedRecord *libdns.Address
 	for _, record := range updatedRecords {
-		if record.Value == "0.0.0.0" {
-			updatedRecord = &record
+		if rr, ok := record.(*libdns.Address); ok && rr.IP.String() == "0.0.0.0" {
+			updatedRecord = rr
+			break
 		}
 	}
 
 	if updatedRecord == nil {
 		t.Fatal("Record was never updated.")
+	}
+}
+
+func TestAllRecordTypes(t *testing.T) {
+	p := &namecheap.Provider{
+		APIKey:      *apiKey,
+		User:        *apiUser,
+		APIEndpoint: *apiEndpoint,
+		ClientIP:    *clientIP,
+	}
+
+	cleanupRecords(t, p, *domain)
+	t.Cleanup(func() {
+		cleanupRecords(t, p, *domain)
+	})
+
+	newRecords := []libdns.Record{
+		&libdns.Address{
+			Name: "a",
+			TTL:  thirtyMinutes,
+			IP:   netip.MustParseAddr("127.0.0.1"),
+		},
+		&libdns.CNAME{
+			Name:   "www",
+			TTL:    thirtyMinutes,
+			Target: *domain,
+		},
+		&libdns.TXT{
+			Name: "txt",
+			TTL:  thirtyMinutes,
+			Text: "test text",
+		},
+		&libdns.MX{
+			Name:       "mx",
+			TTL:        thirtyMinutes,
+			Preference: 10,
+			Target:     "mail.example.com",
+		},
+		&libdns.NS{
+			Name:   "ns",
+			TTL:    thirtyMinutes,
+			Target: "ns1.example.com.",
+		},
+		&libdns.CAA{
+			Name:  "@",
+			TTL:   thirtyMinutes,
+			Flags: 0,
+			Tag:   "issue",
+			Value: "letsencrypt.org",
+		},
+		&libdns.RR{
+			Type: "ALIAS",
+			Name: "alias",
+			Data: "example.com.",
+			TTL:  time.Minute,
+		},
+	}
+
+	t.Logf("Appending: %d Records", len(newRecords))
+
+	addedRecords, err := p.AppendRecords(context.TODO(), *domain, newRecords)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := p.GetRecords(context.TODO(), *domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, record := range addedRecords {
+		// Namecheap adds quotes around the value even if we don't provide them
+		// so adding them here so that the returned records from Append/Delete match
+		// those from GetRecords.
+		if rr, ok := record.(*libdns.CAA); ok {
+			rr.Value = strconv.Quote(rr.Value)
+		}
+		// Namecheap adds a '.' to the end of CNAME records.
+		if rr, ok := record.(*libdns.CNAME); ok {
+			rr.Target = rr.Target + "."
+		}
+	}
+
+	sortRecordsFunc := func(a, b libdns.Record) int {
+		ar := a.RR()
+		br := b.RR()
+
+		if ar.Name != br.Name {
+			return strings.Compare(ar.Name, br.Name)
+		} else if ar.Type != br.Type {
+			return strings.Compare(ar.Type, br.Type)
+		} else if ar.Data != br.Data {
+			return strings.Compare(ar.Data, br.Data)
+		} else if ar.TTL != br.TTL {
+			return int(ar.TTL.Seconds() - br.TTL.Seconds())
+		}
+		return 0
+	}
+
+	slices.SortFunc(addedRecords, sortRecordsFunc)
+	slices.SortFunc(records, sortRecordsFunc)
+
+	if diff := cmp.Diff(addedRecords, records, cmpopts.EquateComparable(netip.Addr{})); diff != "" {
+		t.Fatalf("Added records not equal to fetched records. Diff: %s", diff)
+	}
+
+	_, err = p.DeleteRecords(context.TODO(), *domain, records)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Records deleted: %#v", records)
+
+	records, err = p.GetRecords(context.TODO(), *domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(records) != 0 {
+		t.Fatalf("Expected 0 records. Got: %d", len(records))
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -4,6 +4,11 @@ package namecheap
 
 import (
 	"context"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,22 +18,131 @@ import (
 )
 
 func parseIntoHostRecord(record libdns.Record) namecheap.HostRecord {
-	return namecheap.HostRecord{
-		HostID:     record.ID,
-		RecordType: namecheap.RecordType(record.Type),
-		Name:       record.Name,
-		TTL:        uint16(record.TTL.Seconds()),
-		Address:    record.Value,
+	switch rr := record.(type) {
+	case *libdns.Address:
+		recordType := namecheap.A
+		if rr.IP.Is6() {
+			recordType = namecheap.AAAA
+		}
+		return namecheap.HostRecord{
+			RecordType: recordType,
+			Name:       rr.Name,
+			TTL:        uint16(rr.TTL.Seconds()),
+			Address:    rr.IP.String(),
+		}
+	case *libdns.CNAME:
+		return namecheap.HostRecord{
+			RecordType: namecheap.CNAME,
+			Name:       rr.Name,
+			TTL:        uint16(rr.TTL.Seconds()),
+			Address:    rr.Target,
+		}
+	case *libdns.TXT:
+		return namecheap.HostRecord{
+			RecordType: namecheap.TXT,
+			Name:       rr.Name,
+			TTL:        uint16(rr.TTL.Seconds()),
+			Address:    rr.Text,
+		}
+	case *libdns.MX:
+		// Namecheap requires the target to end in '.'
+		// otherwise it will silently fail to set the record.
+		if !strings.HasSuffix(rr.Target, ".") {
+			rr.Target = rr.Target + "."
+		}
+		return namecheap.HostRecord{
+			RecordType: namecheap.MX,
+			Name:       rr.Name,
+			TTL:        uint16(rr.TTL.Seconds()),
+			Address:    rr.Target,
+			MXPref:     strconv.Itoa(int(rr.Preference)),
+			EmailType:  "MX",
+		}
+	case *libdns.CAA:
+		return namecheap.HostRecord{
+			RecordType: namecheap.CAA,
+			Name:       rr.Name,
+			TTL:        uint16(rr.TTL.Seconds()),
+			Address:    fmt.Sprintf("%d %s %s", rr.Flags, rr.Tag, rr.Value),
+		}
+	default:
+		commonRR := record.RR()
+		return namecheap.HostRecord{
+			RecordType: namecheap.RecordType(commonRR.Type),
+			Name:       commonRR.Name,
+			TTL:        uint16(commonRR.TTL.Seconds()),
+			Address:    commonRR.Data,
+		}
 	}
 }
 
-func parseFromHostRecord(hostRecord namecheap.HostRecord) libdns.Record {
-	return libdns.Record{
-		ID:    hostRecord.HostID,
-		Type:  string(hostRecord.RecordType),
-		Name:  hostRecord.Name,
-		TTL:   time.Duration(hostRecord.TTL) * time.Second,
-		Value: hostRecord.Address,
+// parseFromHostRecord converts a namecheap.HostRecord to a libdns.Record.
+func parseFromHostRecord(hostRecord namecheap.HostRecord) (libdns.Record, error) {
+	switch hostRecord.RecordType {
+	case namecheap.A, namecheap.AAAA:
+		ip, err := netip.ParseAddr(hostRecord.Address)
+		if err != nil {
+			return nil, fmt.Errorf("invalid IP address: %s. Error: %s", hostRecord.Address, err)
+		}
+		return &libdns.Address{
+			Name: hostRecord.Name,
+			TTL:  time.Duration(hostRecord.TTL) * time.Second,
+			IP:   ip,
+		}, nil
+	case namecheap.CNAME:
+		return &libdns.CNAME{
+			Name:   hostRecord.Name,
+			TTL:    time.Duration(hostRecord.TTL) * time.Second,
+			Target: hostRecord.Address,
+		}, nil
+	case namecheap.TXT:
+		return &libdns.TXT{
+			Name: hostRecord.Name,
+			TTL:  time.Duration(hostRecord.TTL) * time.Second,
+			Text: hostRecord.Address,
+		}, nil
+	case namecheap.MX:
+		pref, _ := strconv.Atoi(hostRecord.MXPref)
+		return &libdns.MX{
+			Name:       hostRecord.Name,
+			TTL:        time.Duration(hostRecord.TTL) * time.Second,
+			Preference: uint16(pref),
+			Target:     hostRecord.Address,
+		}, nil
+	case namecheap.NS:
+		return &libdns.NS{
+			Name:   hostRecord.Name,
+			TTL:    time.Duration(hostRecord.TTL) * time.Second,
+			Target: hostRecord.Address,
+		}, nil
+	case namecheap.CAA:
+		// Of the form "0 issue letsencrypt.org"
+		// or with quotes: "0 issue \"letsencrypt.org\""
+		parts := strings.Split(hostRecord.Address, " ")
+		if partLen := len(parts); partLen < 3 {
+			return nil, fmt.Errorf("invalid CAA record: %s. Expected 3 parts, got %d", hostRecord.Address, partLen)
+		}
+		flag, err := strconv.ParseUint(parts[0], 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CAA record: %s. Error parsing flag: %w", hostRecord.Address, err)
+		}
+		tag := parts[1]
+		address := parts[2]
+
+		return &libdns.CAA{
+			Name:  hostRecord.Name,
+			TTL:   time.Duration(hostRecord.TTL) * time.Second,
+			Flags: uint8(flag),
+			Tag:   tag,
+			Value: address,
+		}, nil
+	default:
+		return &libdns.RR{
+			Name: hostRecord.Name,
+			Type: string(hostRecord.RecordType),
+			Data: hostRecord.Address,
+			TTL:  time.Duration(hostRecord.TTL) * time.Second,
+		}, nil
 	}
 }
 
@@ -56,14 +170,17 @@ type Provider struct {
 	// before using the API.
 	ClientIP string `json:"client_ip,omitempty"`
 
+	// These should hardly ever change and are cached on first use.
+	tlds []string
+
+	// These are cached on first use.
+	domains map[string]namecheap.Domain
+
 	mu sync.Mutex
 }
 
 // getClient inititializes a new namecheap client.
 func (p *Provider) getClient() (*namecheap.Client, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	options := []namecheap.ClientOption{}
 	if p.APIEndpoint != "" {
 		options = append(options, namecheap.WithEndpoint(p.APIEndpoint))
@@ -83,53 +200,158 @@ func (p *Provider) getClient() (*namecheap.Client, error) {
 	return client, nil
 }
 
-// GetRecords lists all the records in the zone.
-// This method does return records with the ID field set.
-func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
+func (p *Provider) getTLDs(ctx context.Context) ([]string, error) {
+	if p.tlds != nil {
+		return p.tlds, nil
+	}
+
 	client, err := p.getClient()
 	if err != nil {
 		return nil, err
 	}
 
-	hostRecords, err := client.GetHosts(ctx, zone)
+	tlds, err := client.GetTLDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	p.tlds = make([]string, 0, len(tlds))
+	for _, tld := range tlds {
+		p.tlds = append(p.tlds, tld.Name)
+	}
+
+	return p.tlds, nil
+}
+
+// takes a zone and returns the domain (TLD + SLD separated out) from it.
+func (p *Provider) getDomain(ctx context.Context, zone string) (namecheap.Domain, error) {
+	if p.domains == nil {
+		p.domains = make(map[string]namecheap.Domain)
+	}
+
+	// Normalize zone.
+	zone = strings.TrimRight(zone, ".")
+
+	if domain, ok := p.domains[zone]; ok {
+		return domain, nil
+	}
+
+	tlds, err := p.getTLDs(ctx)
+	if err != nil {
+		return namecheap.Domain{}, err
+	}
+
+	// See if our zone is a substring match of any of the tlds.
+	var domain namecheap.Domain
+	for _, tld := range tlds {
+		if strings.HasSuffix(zone, tld) {
+			domain = namecheap.Domain{
+				TLD: tld,
+				SLD: strings.TrimSuffix(strings.TrimSuffix(zone, tld), "."),
+			}
+			break
+		}
+	}
+
+	if domain.TLD == "" {
+		return namecheap.Domain{}, fmt.Errorf("invalid zone: %s. Zone TLD was not found in list of known TLDs: %s", zone, strings.Join(tlds, ", "))
+	}
+
+	p.domains[zone] = domain
+	return domain, nil
+}
+
+// GetRecords lists all the records in the zone.
+// See https://pkg.go.dev/github.com/libdns/libdns#RecordGetter for more info.
+func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	client, err := p.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	domain, err := p.getDomain(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	hostRecords, err := client.GetHosts(ctx, domain)
 	if err != nil {
 		return nil, err
 	}
 
 	var records []libdns.Record
 	for _, hr := range hostRecords {
-		records = append(records, parseFromHostRecord(hr))
+		record, err := parseFromHostRecord(hr)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
 	}
 
 	return records, nil
 }
 
 // AppendRecords adds records to the zone. It returns the records that were added.
-// Note that the records returned do NOT have their IDs set as the namecheap
-// API does not return this info.
+// The records returned may not exactly match what the Namecheap API returns
+// if you do GetRecords. The ordering of the records is not preserved.
+// See https://pkg.go.dev/github.com/libdns/libdns#RecordAppender for more info.
 func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	var hostRecords []namecheap.HostRecord
-	for _, r := range records {
-		hostRecords = append(hostRecords, parseIntoHostRecord(r))
-	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	client, err := p.getClient()
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = client.AddHosts(ctx, zone, hostRecords)
+	domain, err := p.getDomain(ctx, zone)
 	if err != nil {
 		return nil, err
 	}
 
-	return records, nil
+	// Need to first get the existing hosts before adding new ones since we can only "set hosts" in namecheap api.
+	hosts, err := client.GetHosts(ctx, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	existingHostSet := make(map[namecheap.HostRecordKey]struct{})
+	for _, host := range hosts {
+		existingHostSet[host.AppendKey()] = struct{}{}
+	}
+
+	// Filter any records (name, type, address) that already exist
+	// since we only want to add new ones and not update existing ones.
+	var appendedRecords []libdns.Record
+	for _, record := range records {
+		host := parseIntoHostRecord(record)
+		if _, found := existingHostSet[host.AppendKey()]; !found {
+			hosts = append(hosts, host)
+		}
+		appendedRecords = append(appendedRecords, record)
+	}
+
+	_, err = client.SetHosts(ctx, domain, hosts)
+	if err != nil {
+		return nil, err
+	}
+
+	return appendedRecords, nil
 }
 
 // SetRecords sets the records in the zone, either by updating existing records or creating new ones.
-// It returns the updated records. Note that this method may alter the IDs of existing records on the
-// server but may return records without their IDs set or with their old IDs set.
+// It returns the updated records. The records returned may not exactly match what the Namecheap API returns.
+//
+// For any (name, type) pair in the input, SetRecords ensures that the only
+// records in the output zone with that (name, type) pair are those that were
+// provided in the input. See https://pkg.go.dev/github.com/libdns/libdns#RecordSetter for more info.
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	var hostRecords []namecheap.HostRecord
 	for _, r := range records {
 		hostRecords = append(hostRecords, parseIntoHostRecord(r))
@@ -140,7 +362,30 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 		return nil, err
 	}
 
-	_, err = client.SetHosts(ctx, zone, hostRecords)
+	domain, err := p.getDomain(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+
+	existingHosts, err := client.GetHosts(ctx, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	newHostSet := make(map[namecheap.HostRecordKey]struct{})
+	for _, host := range hostRecords {
+		newHostSet[host.SetKey()] = struct{}{}
+	}
+
+	// Remove existing hosts that have the same name+type as the new ones
+	existingHosts = slices.DeleteFunc(existingHosts, func(h namecheap.HostRecord) bool {
+		_, found := newHostSet[h.SetKey()]
+		return found
+	})
+
+	allHosts := append(existingHosts, hostRecords...)
+
+	_, err = client.SetHosts(ctx, domain, allHosts)
 	if err != nil {
 		return nil, err
 	}
@@ -149,28 +394,62 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 }
 
 // DeleteRecords deletes the records from the zone. It returns the records that were deleted.
-// Note that the records returned do NOT have their IDs set as the namecheap
-// API does not return this info.
+// The records returned may not exactly match what the Namecheap API returns.
+// See https://pkg.go.dev/github.com/libdns/libdns#RecordDeleter for more info.
 func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	var hostRecords []namecheap.HostRecord
-	for _, r := range records {
-		hostRecords = append(hostRecords, parseIntoHostRecord(r))
-	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	client, err := p.getClient()
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = client.DeleteHosts(ctx, zone, hostRecords)
+	domain, err := p.getDomain(ctx, zone)
 	if err != nil {
 		return nil, err
 	}
 
-	return records, nil
+	existingHosts, err := client.GetHosts(ctx, domain)
+	if err != nil {
+		return nil, err
+	}
+
+	hostsToRemove := make(map[namecheap.HostRecordKey]namecheap.HostRecord)
+	for _, record := range records {
+		host := parseIntoHostRecord(record)
+		hostsToRemove[host.DeleteKey()] = host
+	}
+
+	var deletedRecords []libdns.Record
+	var updatedHosts []namecheap.HostRecord
+	for _, host := range existingHosts {
+		// Only add back the existing hosts we don't find.
+		if _, found := hostsToRemove[host.DeleteKey()]; !found {
+			updatedHosts = append(updatedHosts, host)
+		} else {
+			record, err := parseFromHostRecord(host)
+			if err != nil {
+				// If we can't parse the host record, fallback to a generic RR.
+				record = libdns.RR{
+					Name: host.Name,
+					Type: string(host.RecordType),
+					Data: host.Address,
+					TTL:  time.Duration(host.TTL) * time.Second,
+				}
+			}
+			deletedRecords = append(deletedRecords, record)
+		}
+	}
+
+	_, err = client.SetHosts(ctx, domain, updatedHosts)
+	if err != nil {
+		return nil, err
+	}
+
+	return deletedRecords, nil
 }
 
-// Interface guards
 var (
 	_ libdns.RecordGetter   = (*Provider)(nil)
 	_ libdns.RecordAppender = (*Provider)(nil)

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,686 @@
+package namecheap
+
+import (
+	"context"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/libdns/libdns"
+	"github.com/libdns/namecheap/internal/namecheap"
+)
+
+var (
+	thirtyMinutes = time.Duration(30 * time.Minute)
+	oneHour       = time.Duration(1 * time.Hour)
+)
+
+func TestSetRecordsUpdatesExisting(t *testing.T) {
+	testCases := map[string]struct {
+		existingRecords []libdns.Record
+		recordsToUpdate []libdns.Record
+		expectedRecords []libdns.Record
+		zone            string
+	}{
+		"update existing record address": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+				&libdns.Address{
+					Name: "www",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("122.23.3.7"),
+				},
+			},
+			recordsToUpdate: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("0.0.0.0"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "www",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("122.23.3.7"),
+				},
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("0.0.0.0"),
+				},
+			},
+			zone: "domain.com.",
+		},
+		"replace a records keep txt": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  oneHour,
+					IP:   mustParseIP("192.0.2.1"),
+				},
+				&libdns.Address{
+					Name: "@",
+					TTL:  oneHour,
+					IP:   mustParseIP("192.0.2.2"),
+				},
+				&libdns.TXT{
+					Name: "@",
+					TTL:  oneHour,
+					Text: "hello world",
+				},
+			},
+			recordsToUpdate: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  oneHour,
+					IP:   mustParseIP("192.0.2.3"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.TXT{
+					Name: "@",
+					TTL:  oneHour,
+					Text: "hello world",
+				},
+				&libdns.Address{
+					Name: "@",
+					TTL:  oneHour,
+					IP:   mustParseIP("192.0.2.3"),
+				},
+			},
+			zone: "example.com.",
+		},
+		"update alpha keep beta": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::1"),
+				},
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::2"),
+				},
+				&libdns.Address{
+					Name: "beta",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::3"),
+				},
+				&libdns.Address{
+					Name: "beta",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::4"),
+				},
+			},
+			recordsToUpdate: []libdns.Record{
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::1"),
+				},
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::2"),
+				},
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::5"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "beta",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::3"),
+				},
+				&libdns.Address{
+					Name: "beta",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::4"),
+				},
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::1"),
+				},
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::2"),
+				},
+				&libdns.Address{
+					Name: "alpha",
+					TTL:  oneHour,
+					IP:   mustParseIP("2001:db8::5"),
+				},
+			},
+			zone: "example.com.",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ts := namecheap.SetupTestServer(t, convertToHostRecords(tc.existingRecords)...)
+
+			provider := &Provider{
+				APIKey:      "testAPIKey",
+				User:        "testUser",
+				APIEndpoint: ts.URL,
+				ClientIP:    "localhost",
+			}
+
+			_, err := provider.SetRecords(context.TODO(), tc.zone, tc.recordsToUpdate)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			records, err := provider.GetRecords(context.TODO(), tc.zone)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRecords, records, cmpopts.EquateComparable(netip.Addr{})); diff != "" {
+				t.Fatalf("Expected records does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestDeleteRecordsWithExisting(t *testing.T) {
+	testCases := map[string]struct {
+		existingRecords []libdns.Record
+		recordsToDelete []libdns.Record
+		expectedRecords []libdns.Record
+		zone            string
+	}{
+		"delete www record": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+				&libdns.Address{
+					Name: "www",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("122.23.3.7"),
+				},
+			},
+			recordsToDelete: []libdns.Record{
+				&libdns.Address{
+					Name: "www",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("122.23.3.7"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+			},
+			zone: "domain.com.",
+		},
+		"non-existing record does not delete existing record": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+			},
+			recordsToDelete: []libdns.Record{
+				&libdns.Address{
+					Name: "www",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("122.23.3.7"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+			},
+			zone: "domain.co.uk.",
+		},
+		"partial match does not delete record": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+			},
+			recordsToDelete: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.1.1.1"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "@",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("1.2.3.4"),
+				},
+			},
+			zone: "domain.co.uk.",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ts := namecheap.SetupTestServer(t, convertToHostRecords(tc.existingRecords)...)
+
+			provider := &Provider{
+				APIKey:      "testAPIKey",
+				User:        "testUser",
+				APIEndpoint: ts.URL,
+				ClientIP:    "localhost",
+			}
+
+			_, err := provider.DeleteRecords(context.TODO(), tc.zone, tc.recordsToDelete)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			records, err := provider.GetRecords(context.TODO(), tc.zone)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRecords, records, cmpopts.EquateComparable(netip.Addr{})); diff != "" {
+				t.Fatalf("Expected records does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestConcurrentDeleteRecords(t *testing.T) {
+	ts := namecheap.SetupTestServer(t)
+
+	// Create provider with mock endpoint
+	provider := &Provider{
+		APIKey:      "test-key",
+		User:        "test-user",
+		APIEndpoint: ts.URL,
+		ClientIP:    "127.0.0.1",
+	}
+
+	zone := "example.com."
+
+	record1 := &libdns.Address{
+		Name: "test1",
+		TTL:  30 * time.Minute,
+		IP:   mustParseIP("1.1.1.1"),
+	}
+	record2 := &libdns.Address{
+		Name: "test2",
+		TTL:  30 * time.Minute,
+		IP:   mustParseIP("2.2.2.2"),
+	}
+	record3 := &libdns.Address{
+		Name: "test3",
+		TTL:  30 * time.Minute,
+		IP:   mustParseIP("3.3.3.3"),
+	}
+
+	_, err := provider.AppendRecords(context.Background(), zone, []libdns.Record{record1, record2, record3})
+	if err != nil {
+		t.Fatalf("Failed to add initial records: %v", err)
+	}
+
+	// Get the records because the IDs are not set in the AppendRecords response.
+	records, err := provider.GetRecords(context.Background(), zone)
+	if err != nil {
+		t.Fatalf("Failed to get records: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		if _, err := provider.DeleteRecords(context.Background(), zone, []libdns.Record{records[0]}); err != nil {
+			t.Errorf("First DeleteRecords failed: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		if _, err := provider.DeleteRecords(context.Background(), zone, []libdns.Record{records[1]}); err != nil {
+			t.Errorf("Second DeleteRecords failed: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	remainingRecords, err := provider.GetRecords(context.Background(), zone)
+	if err != nil {
+		t.Fatalf("Failed to get remaining records: %v", err)
+	}
+
+	if len(remainingRecords) != 1 {
+		t.Errorf("Expected 1 remaining record, got %d", len(remainingRecords))
+	}
+}
+
+func TestConcurrentSetRecords(t *testing.T) {
+	ts := namecheap.SetupTestServer(t)
+
+	provider := &Provider{
+		APIKey:      "test-key",
+		User:        "test-user",
+		APIEndpoint: ts.URL,
+		ClientIP:    "127.0.0.1",
+	}
+
+	zone := "example.com."
+
+	record1 := &libdns.Address{
+		Name: "test1",
+		TTL:  30 * time.Minute,
+		IP:   mustParseIP("1.1.1.1"),
+	}
+
+	_, err := provider.SetRecords(context.Background(), zone, []libdns.Record{record1})
+	if err != nil {
+		t.Fatalf("Failed to add initial record: %v", err)
+	}
+
+	records, err := provider.GetRecords(context.Background(), zone)
+	if err != nil {
+		t.Fatalf("Failed to get records: %v", err)
+	}
+
+	modifiedRecord1 := &libdns.Address{
+		Name: records[0].RR().Name,
+		TTL:  records[0].RR().TTL,
+		IP:   mustParseIP("1.1.1.2"),
+	}
+
+	modifiedRecord1Again := &libdns.Address{
+		Name: records[0].RR().Name,
+		TTL:  records[0].RR().TTL,
+		IP:   mustParseIP("1.1.1.3"),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, err := provider.SetRecords(context.Background(), zone, []libdns.Record{modifiedRecord1})
+		if err != nil {
+			t.Errorf("First SetRecords failed: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, err := provider.SetRecords(context.Background(), zone, []libdns.Record{modifiedRecord1Again})
+		if err != nil {
+			t.Errorf("Second SetRecords failed: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	remainingRecords, err := provider.GetRecords(context.Background(), zone)
+	if err != nil {
+		t.Fatalf("Failed to get remaining records: %v", err)
+	}
+
+	if len(remainingRecords) != 1 {
+		t.Errorf("Expected 1 record, got %d", len(remainingRecords))
+	}
+}
+
+func TestAppendRecords(t *testing.T) {
+	threeMinutes := 3 * time.Minute
+	testCases := map[string]struct {
+		existingRecords []libdns.Record
+		recordsToAppend []libdns.Record
+		expectedRecords []libdns.Record
+		zone            string
+	}{
+		"append two address records": {
+			recordsToAppend: []libdns.Record{
+				&libdns.Address{
+					Name: "first_host",
+					TTL:  threeMinutes,
+					IP:   netip.IPv4Unspecified(),
+				},
+				&libdns.Address{
+					Name: "second_host",
+					TTL:  0,
+					IP:   netip.IPv4Unspecified(),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "first_host",
+					TTL:  threeMinutes,
+					IP:   netip.IPv4Unspecified(),
+				},
+				&libdns.Address{
+					Name: "second_host",
+					TTL:  0,
+					IP:   netip.IPv4Unspecified(),
+				},
+			},
+			zone: "domain.com.",
+		},
+		"append single record with default TTL": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "existing_host",
+					TTL:  30 * time.Minute,
+					IP:   mustParseIP("192.168.1.1"),
+				},
+			},
+			recordsToAppend: []libdns.Record{
+				&libdns.Address{
+					Name: "new_host",
+					TTL:  0,
+					IP:   netip.IPv4Unspecified(),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "existing_host",
+					TTL:  30 * time.Minute,
+					IP:   mustParseIP("192.168.1.1"),
+				},
+				&libdns.Address{
+					Name: "new_host",
+					TTL:  0,
+					IP:   netip.IPv4Unspecified(),
+				},
+			},
+			zone: "example.com.",
+		},
+		"append mixed record types": {
+			recordsToAppend: []libdns.Record{
+				&libdns.Address{
+					Name: "mixed_host",
+					TTL:  5 * time.Minute,
+					IP:   netip.IPv4Unspecified(),
+				},
+				&libdns.TXT{
+					Name: "mixed_txt",
+					TTL:  10 * time.Minute,
+					Text: "test text",
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "mixed_host",
+					TTL:  5 * time.Minute,
+					IP:   netip.IPv4Unspecified(),
+				},
+				&libdns.TXT{
+					Name: "mixed_txt",
+					TTL:  10 * time.Minute,
+					Text: "test text",
+				},
+			},
+			zone: "mixed.com.",
+		},
+		"append existing record with different TTL should not return record": {
+			existingRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "existing",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("192.168.1.1"),
+				},
+			},
+			recordsToAppend: []libdns.Record{
+				&libdns.Address{
+					Name: "existing",
+					TTL:  oneHour,
+					IP:   mustParseIP("192.168.1.1"),
+				},
+			},
+			expectedRecords: []libdns.Record{
+				&libdns.Address{
+					Name: "existing",
+					TTL:  thirtyMinutes,
+					IP:   mustParseIP("192.168.1.1"),
+				},
+			},
+			zone: "example.com.",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ts := namecheap.SetupTestServer(t, convertToHostRecords(tc.existingRecords)...)
+
+			provider := &Provider{
+				APIKey:      "testAPIKey",
+				User:        "testUser",
+				APIEndpoint: ts.URL,
+				ClientIP:    "localhost",
+			}
+
+			records, err := provider.AppendRecords(context.Background(), tc.zone, tc.recordsToAppend)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+			if diff := cmp.Diff(tc.recordsToAppend, records, cmpopts.EquateComparable(netip.Addr{})); diff != "" {
+				t.Fatalf("Expected records does not match: %s", diff)
+			}
+
+			allRecords, err := provider.GetRecords(context.Background(), tc.zone)
+			if err != nil {
+				t.Fatalf("Failed to get records: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedRecords, allRecords, cmpopts.EquateComparable(netip.Addr{})); diff != "" {
+				t.Fatalf("Expected records does not match: %s", diff)
+			}
+		})
+	}
+}
+
+func TestAppendRecordsConcurrent(t *testing.T) {
+	ts := namecheap.SetupTestServer(t)
+
+	provider := &Provider{
+		APIKey:      "test-key",
+		User:        "test-user",
+		APIEndpoint: ts.URL,
+		ClientIP:    "127.0.0.1",
+	}
+
+	zone := "example.com"
+
+	record1 := &libdns.Address{
+		Name: "test1",
+		TTL:  thirtyMinutes,
+		IP:   mustParseIP("1.1.1.1"),
+	}
+	record2 := &libdns.Address{
+		Name: "test2",
+		TTL:  thirtyMinutes,
+		IP:   mustParseIP("2.2.2.2"),
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_, err := provider.AppendRecords(context.Background(), zone, []libdns.Record{record1})
+		if err != nil {
+			t.Errorf("First AppendRecords failed: %v", err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, err := provider.AppendRecords(context.Background(), zone, []libdns.Record{record2})
+		if err != nil {
+			t.Errorf("Second AppendRecords failed: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	remainingRecords, err := provider.GetRecords(context.Background(), zone)
+	if err != nil {
+		t.Fatalf("Failed to get remaining records: %v", err)
+	}
+
+	if len(remainingRecords) != 2 {
+		t.Errorf("Expected 2 records, got %d", len(remainingRecords))
+	}
+
+	recordMap := make(map[string]bool)
+	for _, r := range remainingRecords {
+		rr := r.RR()
+		if addr, ok := r.(*libdns.Address); ok {
+			recordMap[rr.Name+addr.IP.String()] = true
+		}
+	}
+
+	if !recordMap[record1.RR().Name+record1.IP.String()] {
+		t.Errorf("record1 (%s) was not added", record1.RR().Name+record1.IP.String())
+	}
+	if !recordMap[record2.RR().Name+record2.IP.String()] {
+		t.Errorf("record2 (%s) was not added", record2.RR().Name+record2.IP.String())
+	}
+}
+
+func convertToHostRecords(records []libdns.Record) []namecheap.HostRecord {
+	var hostRecords []namecheap.HostRecord
+	for _, r := range records {
+		hostRecords = append(hostRecords, parseIntoHostRecord(r))
+	}
+	return hostRecords
+}
+
+// Helper function to parse IP addresses for test data
+func mustParseIP(ipStr string) netip.Addr {
+	ip, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		panic(err)
+	}
+	return ip
+}


### PR DESCRIPTION
This is a large update which upgrades libdns to v1 and reworks a lot of the implementation and testing as a result.

Changes:
- libdns v1
- Always uses `POST` and sends the query params as a URL encoded string.
- Does not use Host IDs anymore since these are not present on libdns v1 types. How records are found varies depending on the method being called as defined in [libdns package](https://pkg.go.dev/github.com/libdns/libdns#pkg-overview).
- Domain provided is compared against namecheap's list of TLDs and this is used to split TLD from SLD.
- Moves most of the implementation and testing into the `Provider` itself.