### PR TITLE
Fix TLD matching for domains like .website

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -241,6 +241,11 @@ func (p *Provider) getDomain(ctx context.Context, zone string) (namecheap.Domain
 		return namecheap.Domain{}, err
 	}
 
+	// Sort TLDs by length (longest first) to avoid matching "site" before "website"
+	slices.SortFunc(tlds, func(a, b string) int {
+		return len(b) - len(a)
+	})
+
 	// See if our zone is a substring match of any of the tlds.
 	var domain namecheap.Domain
 	for _, tld := range tlds {


### PR DESCRIPTION
## Problem
After the libdns v1 upgrade, wildcard certificate renewal fails for domains using TLDs that are substrings of other TLDs (e.g., `.website` ends with `.site`).

The `getDomain` function iterates through TLDs and matches the first suffix found. If `site` is checked before `website`, it incorrectly matches:
- Zone: `afake.website`
- Matched TLD: `site` (because "website" ends with "site")
- Computed SLD: `afake.web`
- Result: Namecheap API returns "Domain name not found"

## Solution
Sort TLDs by length (longest first) before matching, so `website` is checked before `site`.

## Testing
Tested with a `.website` domain that was previously failing. Wildcard certificate now renews successfully.